### PR TITLE
Feature InjectionIII support

### DIFF
--- a/InjectionTDD.podspec
+++ b/InjectionTDD.podspec
@@ -19,6 +19,8 @@ give full TDD experience.
   s.social_media_url = 'https://twitter.com/norapsi'
 
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.11'
+  s.tvos.deployment_target = '9.2'
 
   s.source_files = 'InjectionTDD/Classes/**/*'
   s.pod_target_xcconfig = { 'GCC_GENERATE_DEBUGGING_SYMBOLS' => 'NO' }

--- a/InjectionTDD/Classes/TDDTestKeeper.m
+++ b/InjectionTDD/Classes/TDDTestKeeper.m
@@ -40,8 +40,8 @@
 #endif
 
     NSArray *paths = [NSArray arrayWithObjects:
-                      injectionForXcode,
                       injectionIII,
+                      injectionForXcode,
                       nil];
 
     BOOL isDirectory = NO;

--- a/InjectionTDD/Classes/TDDTestKeeper.m
+++ b/InjectionTDD/Classes/TDDTestKeeper.m
@@ -26,13 +26,16 @@
     NSString *injectionForXcode = @"/tmp/injectionforxcode";
     NSString *injectionIII = @"/Applications/InjectionIII.app/Contents/Resources/";
 
-#if TARGET_OS_IPHONE
+
+#ifdef TARGET_OS_IOS
     NSString *platformString = @"iOSInjection{version}.bundle";
 #endif
-#if TARGET_OS_TVOS
-    NSString *platformString = @"tvOSInjection{version}.bundle";
+
+#ifdef TARGET_OS_TV
+    platformString = @"tvOSInjection{version}.bundle";
 #endif
-#if TARGET_OS_MACOS
+
+#ifdef TARGET_OS_MACOS
     NSString *platformString = @"macOSInjection{version}.bundle";
 #endif
 


### PR DESCRIPTION
Adds support for `InjectionIII`

The new implementation will try to look for `InjectionIII` and `injectionforxcode`, the first path that can be resolved will be used. InjectionIII takes precedence of injectionforxcode because that version of Injection for Xcode is newer and is currently being maintained. In addition to loading InjectionIII bundle, it will also try and resolve the different versions of the bundle, the first one being the one that is built for Xcode 10 and if that one cannot be resolved it will try and load the Xcode 9 fallback version.

In addition to the new support for InjectionIII, it also adds new targets to the pod spec so that InjectionTDD can be used on macOS and tvOS.